### PR TITLE
npm/npmjs/-/node-releases/1.1.11

### DIFF
--- a/curations/npm/npmjs/-/node-releases.yaml
+++ b/curations/npm/npmjs/-/node-releases.yaml
@@ -6,3 +6,6 @@ revisions:
   1.1.1:
     licensed:
       declared: Apache-1.1
+  1.1.11:
+    licensed:
+      declared: Apache-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm/npmjs/-/node-releases/1.1.11

**Details:**
Add Apache-1.1 license

**Resolution:**
Auto-generated curation. Newly harvested version 1.1.11 matches existing version 1.1.1. 
Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [node-releases 1.1.11](https://clearlydefined.io/definitions/npm/npmjs/-/node-releases/1.1.11)

