### PR TITLE
npm/npmjs/-/chrome-devtools-frontend/1.0.644467

### DIFF
--- a/curations/npm/npmjs/-/chrome-devtools-frontend.yaml
+++ b/curations/npm/npmjs/-/chrome-devtools-frontend.yaml
@@ -15,3 +15,6 @@ revisions:
   1.0.543547:
     licensed:
       declared: BSD-3-Clause
+  1.0.644467:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm/npmjs/-/chrome-devtools-frontend/1.0.644467

**Details:**
Add BSD-3-Clause license

**Resolution:**
Auto-generated curation. Newly harvested version 1.0.644467 matches existing version 1.0.447208. 
Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'SEE LICENSE IN https://chromium.googlesource.com/chromium/src/+/master/LICENSE'

**Affected definitions**:
- [chrome-devtools-frontend 1.0.644467](https://clearlydefined.io/definitions/npm/npmjs/-/chrome-devtools-frontend/1.0.644467)

