### PR TITLE
npm node-releases@1.1.1

### DIFF
--- a/curations/npm/npmjs/-/node-releases.yaml
+++ b/curations/npm/npmjs/-/node-releases.yaml
@@ -5,4 +5,16 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: Apache-1.1
+      declared: MIT-feh
+  1.1.10:
+    licensed:
+      declared: MIT-feh
+  1.1.11:
+    licensed:
+      declared: MIT-feh
+  1.1.12:
+    licensed:
+      declared: MIT-feh
+  1.1.13:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm node-releases@1.1.1

**Details:**
Test

**Resolution:**
Test

**Affected definitions**:
- [node-releases 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/node-releases/1.1.1)

**Automatically added versions:**
- 1.1.10
- 1.1.11
- 1.1.12
- 1.1.13

Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'