### PR TITLE
npm/npmjs/-/node-releases/1.1.14

### DIFF
--- a/curations/npm/npmjs/-/node-releases.yaml
+++ b/curations/npm/npmjs/-/node-releases.yaml
@@ -18,3 +18,6 @@ revisions:
   1.1.13:
     licensed:
       declared: MIT-feh
+  1.1.14:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm/npmjs/-/node-releases/1.1.14

**Details:**
Add MIT-feh license

**Resolution:**
Auto-generated curation. Newly harvested version 1.1.14 matches existing version 1.1.10. 
Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [node-releases 1.1.14](https://clearlydefined.io/definitions/npm/npmjs/-/node-releases/1.1.14)

