### PR TITLE
npm chrome-devtools-frontend

### DIFF
--- a/curations/npm/npmjs/-/chrome-devtools-frontend.yaml
+++ b/curations/npm/npmjs/-/chrome-devtools-frontend.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: chrome-devtools-frontend
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.440939:
+    licensed:
+      declared: BSD-3-Clause
+  1.0.447208:
+    licensed:
+      declared: BSD-3-Clause
+  1.0.540722:
+    licensed:
+      declared: BSD-3-Clause
+  1.0.543547:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm chrome-devtools-frontend

**Details:**
Test

**Resolution:**
Test

**Affected definitions**:
- [chrome-devtools-frontend 1.0.440939](https://clearlydefined.io/definitions/npm/npmjs/-/chrome-devtools-frontend/1.0.440939)

**Automatically added versions:**
- 1.0.447208
- 1.0.540722
- 1.0.543547

Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'SEE LICENSE IN https://chromium.googlesource.com/chromium/src/+/master/LICENSE'