### PR TITLE
npm/npmjs/-/angular/1.6.9

### DIFF
--- a/curations/npm/npmjs/-/angular.yaml
+++ b/curations/npm/npmjs/-/angular.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.6.10:
+    licensed:
+      declared: MIT-feh
   1.6.9:
     licensed:
       declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/angular/1.6.9

**Details:**
Add undefined license

**Resolution:**
Auto-generated curation based on merged curation for npm/npmjs/-/angular/1.6.9
- 1.6.10

Matching license file(s): package/LICENSE.md
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [angular 1.6.10](https://clearlydefined.io/definitions/npm/npmjs/-/angular/1.6.10)