### PR TITLE
npm/npmjs/-/mocha/5.0.1

### DIFF
--- a/curations/npm/npmjs/-/mocha.yaml
+++ b/curations/npm/npmjs/-/mocha.yaml
@@ -6,3 +6,6 @@ revisions:
   5.0.1:
     licensed:
       declared: MIT-feh
+  5.0.2:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/mocha/5.0.1

**Details:**
Add MIT-feh license

**Resolution:**
Auto-generated curation base on https://github.com/MichaelTsengLZ/curated-data-dev/pull/40
 - 5.0.2

Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [mocha 5.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/mocha/5.0.2)