### PR TITLE
npm/npmjs/-/mocha/5.1.1

### DIFF
--- a/curations/npm/npmjs/-/mocha.yaml
+++ b/curations/npm/npmjs/-/mocha.yaml
@@ -6,3 +6,6 @@ revisions:
   5.0.1:
     licensed:
       declared: MIT-feh
+  5.1.1:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/mocha/5.1.1

**Details:**
Add MIT-feh license

**Resolution:**
Auto-generated curation. Newly harvested version 5.1.1 matches existing version 5.0.1. 
Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [mocha 5.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/mocha/5.1.1)