### PR TITLE
npm/npmjs/-/mocha/5.0.1

### DIFF
--- a/curations/npm/npmjs/-/mocha.yaml
+++ b/curations/npm/npmjs/-/mocha.yaml
@@ -6,3 +6,12 @@ revisions:
   5.0.1:
     licensed:
       declared: MIT-feh
+  5.0.3:
+    licensed:
+      declared: MIT-feh
+  5.1.0:
+    licensed:
+      declared: MIT-feh
+  5.1.1:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/mocha/5.0.1

**Details:**
Add undefined license

**Resolution:**
Auto-generated curation based on merged curation for npm/npmjs/-/mocha/5.0.1
- 5.0.3
- 5.1.0
- 5.1.1

Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [mocha 5.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/mocha/5.0.3)