### PR TITLE
npm/npmjs/-/lodash/1.1.1

### DIFF
--- a/curations/npm/npmjs/-/lodash.yaml
+++ b/curations/npm/npmjs/-/lodash.yaml
@@ -3,6 +3,18 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.0:
+    licensed:
+      declared: MIT-feh
+  1.0.1:
+    licensed:
+      declared: MIT-feh
   1.1.1:
+    licensed:
+      declared: MIT-feh
+  1.2.1:
+    licensed:
+      declared: MIT-feh
+  1.3.0:
     licensed:
       declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/lodash/1.1.1

**Details:**
Add MIT-feh license

**Resolution:**
Auto-generated curation base on https://github.com/MichaelTsengLZ/curated-data-dev/pull/49
 - 1.0.0
- 1.0.1
- 1.2.1
- 1.3.0

Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [lodash 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/lodash/1.0.1)