### PR TITLE
npm/npmjs/-/lodash/1.3.1

### DIFF
--- a/curations/npm/npmjs/-/lodash.yaml
+++ b/curations/npm/npmjs/-/lodash.yaml
@@ -6,3 +6,6 @@ revisions:
   1.1.1:
     licensed:
       declared: MIT-feh
+  1.3.1:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/lodash/1.3.1

**Details:**
Add MIT-feh license

**Resolution:**
Auto-generated curation. Newly harvested version 1.3.1 matches existing version 1.1.1. 
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [lodash 1.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/lodash/1.3.1)