### PR TITLE
npm/npmjs/-/express/4.0.0

### DIFF
--- a/curations/npm/npmjs/-/express.yaml
+++ b/curations/npm/npmjs/-/express.yaml
@@ -6,3 +6,9 @@ revisions:
   4.0.0:
     licensed:
       declared: MIT-feh
+  4.1.0:
+    licensed:
+      declared: MIT-feh
+  4.2.0:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/express/4.0.0

**Details:**
Add MIT-feh license

**Resolution:**
Automatically added versions based on https://github.com/MichaelTsengLZ/curated-data-dev/pull/53
 - 4.1.0
- 4.2.0

Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [express 4.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/express/4.2.0)