### PR TITLE
npm/npmjs/-/express/4.3.0

### DIFF
--- a/curations/npm/npmjs/-/express.yaml
+++ b/curations/npm/npmjs/-/express.yaml
@@ -12,3 +12,6 @@ revisions:
   4.2.0:
     licensed:
       declared: MIT-feh
+  4.3.0:
+    licensed:
+      declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/express/4.3.0

**Details:**
Add MIT-feh license

**Resolution:**
Auto-generated curation. Newly harvested version 4.3.0 matches existing version 4.2.0. 
Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: 'MIT'

**Affected definitions**:
- [express 4.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/express/4.3.0)