### PR TITLE
npm/npmjs/-/express/4.1.0

### DIFF
--- a/curations/npm/npmjs/-/express.yaml
+++ b/curations/npm/npmjs/-/express.yaml
@@ -9,6 +9,9 @@ revisions:
   4.1.0:
     licensed:
       declared: MIT
+  4.1.1:
+    licensed:
+      declared: MIT
   4.2.0:
     licensed:
       declared: MIT-feh


### PR DESCRIPTION

**Type:** Auto

**Summary:**
npm/npmjs/-/express/4.1.0

**Details:**
Add MIT license

**Resolution:**
Automatically added versions based on https://github.com/MichaelTsengLZ/curated-data-dev/pull/56
 - 4.1.1

Matching license file(s): package/LICENSE
Matching metadata: registryData.manifest.license: "MIT"

**Affected definitions**:
- [express 4.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/express/4.1.1)